### PR TITLE
don't fail kinit for ECHILD

### DIFF
--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -203,12 +203,14 @@ static int rd_kafka_sasl_cyrus_kinit_refresh (rd_kafka_t *rk) {
         mtx_unlock(&rd_kafka_sasl_cyrus_kinit_lock);
 
         if (r == -1) {
-                rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
-                             "Kerberos ticket refresh failed: "
-                             "Failed to execute %s",
-                             cmd);
-                rd_free(cmd);
-                return -1;
+                if (errno != ECHILD) {
+                        rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
+                                     "Kerberos ticket refresh failed, errno=%d: "
+                                     "Failed to execute %s",
+                                     errno, cmd);
+                        rd_free(cmd);
+                        return -1;
+                }
         } else if (WIFSIGNALED(r)) {
                 rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
                              "Kerberos ticket refresh failed: %s: "


### PR DESCRIPTION
When librdkafka is used as a plugin and there is a signal handler that ignores ECHILD for plugins the kinit system call returns a -1 with errno ECHILD.  This can be safely ignored and just means the command finished before the wait for it could be issued.  This fixes an issue with pmacct using librdkafka as a plugin.